### PR TITLE
fix: use serverless views in case of a Multi-AZ provisioned cluster

### DIFF
--- a/redshift/config.go
+++ b/redshift/config.go
@@ -73,6 +73,13 @@ func (c *Config) IsServerless(db *DBConnection) (bool, error) {
 
 	// Insuficcient privileges means we do not have access to this view ergo we run on Redshift classic
 	if isPqErrorWithCode(err, pgErrorCodeInsufficientPrivileges) {
+         _, err := db.Query("SELECT 1 FROM SVL_QUERY_SUMMARY")
+        // An error means we are running Multi-AZ Provisioned Redshift which behaves in some cases as serverless
+        if err != nil {
+            c.isServerless = true
+            return true, nil
+        }
+
 		c.isServerless = false
 		return false, nil
 	}


### PR DESCRIPTION
This fixes support for Multi-AZ provisioned clusters where the `svv_schema_quota_state` system view does not work but the variant used for serverless workgroups does (`svv_redshift_schema_quota`).

> You can't use STL, SVCS, SVL, SVV, STV views with Multi-AZ deployments as they only support system monitoring views (SYS_* views). Change your monitoring queries to use system monitoring views (SYS_* views). ([AWS docs](https://docs.aws.amazon.com/redshift/latest/mgmt/overview-multi-az.html#:~:text=You%20can%27t%20use%20STL%2C%20SVCS%2C%20SVL%2C%20SVV%2C%20STV%20views%20with%20Multi%2DAZ%20deployments%20as%20they%20only%20support%20system%20monitoring%20views%20(SYS_*%20views).%20Change%20your%20monitoring%20queries%20to%20use%20system%20monitoring%20views%20(SYS_*%20views).))