### PR TITLE
feat(resource_redshift_database): basic zeroetl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Due to limited testing capacities, the following features are not tested/stable 
     * RDS Postgres Database
     * RDS MySQL Database
     * Redshift Database
+    * ZeroETL Integration
 * Temporary Credentials Cluster Identifier
 * Temporary Credentials Assume Role
 * Datashares

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -52,6 +52,7 @@ resource "redshift_database" "datashare_db" {
 - `connection_limit` (Number) The maximum number of concurrent connections that can be made to this database. A value of -1 means no limit.
 - `datashare_source` (Block List, Max: 1) Configuration for creating a database from a redshift datashare. (see [below for nested schema](#nestedblock--datashare_source))
 - `owner` (String) Owner of the database, usually the user who created it
+- `zeroetl_integration` (Block List, Max: 1) Configuration for creating a database from a zero ETL integration. (see [below for nested schema](#nestedblock--zeroetl_integration))
 
 ### Read-Only
 
@@ -69,3 +70,11 @@ Optional:
 
 - `account_id` (String) The AWS account ID of the producer cluster.
 - `with_permissions` (Boolean) Whether the database requires object-level permissions to access individual database objects
+
+
+<a id="nestedblock--zeroetl_integration"></a>
+### Nested Schema for `zeroetl_integration`
+
+Required:
+
+- `integration_id` (String) The unique identifier of the zero ETL integration

--- a/redshift/resource_redshift_database.go
+++ b/redshift/resource_redshift_database.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/lib/pq"
@@ -33,7 +34,10 @@ func redshiftDatabase() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: forceNewIfListSizeChanged(databaseDatashareSourceAttr),
+		CustomizeDiff: customdiff.All(
+			forceNewIfListSizeChanged(databaseDatashareSourceAttr),
+			forceNewIfListSizeChanged(databaseZeroETLIntegrationAttr),
+		),
 		Schema: map[string]*schema.Schema{
 			databaseNameAttr: {
 				Type:        schema.TypeString,

--- a/redshift/resource_redshift_database.go
+++ b/redshift/resource_redshift_database.go
@@ -201,7 +201,7 @@ func resourceRedshiftDatabaseCreateInternal(db *DBConnection, d *schema.Resource
 	// Handle Zero ETL integration source if specified
 	if _, isZeroETLIntegration := d.GetOk(fmt.Sprintf("%s.0.%s", databaseZeroETLIntegrationAttr, databaseZeroETLIntegrationIdAttr)); isZeroETLIntegration {
 		integrationId := d.Get(fmt.Sprintf("%s.0.%s", databaseZeroETLIntegrationAttr, databaseZeroETLIntegrationIdAttr)).(string)
-		query = fmt.Sprintf("%s FROM INTEGRATION %s", query, pq.QuoteLiteral(integrationId))
+		query = fmt.Sprintf("%s FROM INTEGRATION '%s'", query, pqQuoteLiteral(integrationId))
 	}
 
 	if v, ok := d.GetOk(databaseOwnerAttr); ok {

--- a/redshift/resource_redshift_database.go
+++ b/redshift/resource_redshift_database.go
@@ -277,6 +277,13 @@ WHERE pg_database_info.datid = $1
 	}
 	d.Set(databaseDatashareSourceAttr, dataShareConfiguration)
 
+	// We have no logic to query the cluster to determine if a database is associated
+	// with a zero ETL integration, so we preserve the config value in state.
+	// This won't survive an import, but prevents perpetual diffs during normal lifecycle.
+	if v, ok := d.GetOk(databaseZeroETLIntegrationAttr); ok {
+		d.Set(databaseZeroETLIntegrationAttr, v)
+	}
+
 	return nil
 }
 

--- a/redshift/resource_redshift_database.go
+++ b/redshift/resource_redshift_database.go
@@ -57,11 +57,11 @@ func redshiftDatabase() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(-1),
 			},
 			databaseDatashareSourceAttr: {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MaxItems:     1,
-				Description:  "Configuration for creating a database from a redshift datashare.",
-				ExactlyOneOf: []string{databaseDatashareSourceAttr, databaseZeroETLIntegrationAttr},
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Description:   "Configuration for creating a database from a redshift datashare.",
+				ConflictsWith: []string{databaseZeroETLIntegrationAttr},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						databaseDatashareSourceShareNameAttr: {
@@ -101,11 +101,11 @@ func redshiftDatabase() *schema.Resource {
 				},
 			},
 			databaseZeroETLIntegrationAttr: {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MaxItems:     1,
-				Description:  "Configuration for creating a database from a zero ETL integration.",
-				ExactlyOneOf: []string{databaseDatashareSourceAttr, databaseZeroETLIntegrationAttr},
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Description:   "Configuration for creating a database from a zero ETL integration.",
+				ConflictsWith: []string{databaseDatashareSourceAttr},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						databaseZeroETLIntegrationIdAttr: {

--- a/redshift/resource_redshift_database_test.go
+++ b/redshift/resource_redshift_database_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -94,6 +95,37 @@ resource "redshift_user" "user" {
 			},
 		},
 	})
+}
+
+func TestAccResourceRedshiftDatabase_ZeroETLConflictsWithDatashare(t *testing.T) {
+	dbName := strings.ReplaceAll(acctest.RandomWithPrefix("tf_acc_conflict"), "-", "_")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceRedshiftDatabaseConfigZeroETLConflict(dbName),
+				ExpectError: regexp.MustCompile(`"zeroetl_integration": conflicts with datashare_source`),
+			},
+		},
+	})
+}
+
+func testAccResourceRedshiftDatabaseConfigZeroETLConflict(dbName string) string {
+	return fmt.Sprintf(`
+resource "redshift_database" "db" {
+  %[1]s = %[2]q
+  %[3]s {
+    %[4]s = "some-share"
+    %[5]s = "00000000-0000-0000-0000-000000000000"
+  }
+  %[6]s {
+    %[7]s = "arn:aws:glue:us-east-1:123456789012:integration/some-integration-id"
+  }
+}
+`, databaseNameAttr, dbName,
+		databaseDatashareSourceAttr, databaseDatashareSourceShareNameAttr, databaseDatashareSourceNamespaceAttr,
+		databaseZeroETLIntegrationAttr, databaseZeroETLIntegrationIdAttr)
 }
 
 func testAccCheckRedshiftDatabaseDestroy(s *terraform.State) error {

--- a/redshift/resource_redshift_database_test.go
+++ b/redshift/resource_redshift_database_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -95,6 +96,46 @@ resource "redshift_user" "user" {
 			},
 		},
 	})
+}
+
+func TestAccResourceRedshiftDatabase_ZeroETL(t *testing.T) {
+	integrationId := os.Getenv("REDSHIFT_ZERO_ETL_INTEGRATION_ID")
+	if integrationId == "" {
+		t.Skip("REDSHIFT_ZERO_ETL_INTEGRATION_ID not set, skipping zero ETL acceptance test")
+	}
+	dbName := strings.ReplaceAll(acctest.RandomWithPrefix("tf_acc_zeroetl"), "-", "_")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckRedshiftDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceRedshiftDatabaseConfigZeroETL(dbName, integrationId),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDatabaseExists(dbName),
+					resource.TestCheckResourceAttr("redshift_database.db", databaseNameAttr, dbName),
+					resource.TestCheckResourceAttr(
+						"redshift_database.db",
+						fmt.Sprintf("%s.0.%s", databaseZeroETLIntegrationAttr, databaseZeroETLIntegrationIdAttr),
+						integrationId,
+					),
+				),
+			},
+			// ImportState is intentionally omitted: the Redshift catalog does not expose
+			// the integration ID, so imported state cannot be verified.
+		},
+	})
+}
+
+func testAccResourceRedshiftDatabaseConfigZeroETL(dbName, integrationId string) string {
+	return fmt.Sprintf(`
+resource "redshift_database" "db" {
+  %[1]s = %[2]q
+  %[3]s {
+    %[4]s = %[5]q
+  }
+}
+`, databaseNameAttr, dbName, databaseZeroETLIntegrationAttr, databaseZeroETLIntegrationIdAttr, integrationId)
 }
 
 func TestAccResourceRedshiftDatabase_ZeroETLConflictsWithDatashare(t *testing.T) {


### PR DESCRIPTION
SmallPR which enables zeroetl support for the database resource

Unfortunately, I haven't found a way to query on the cluster if a db is associated with an integration

Ref: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_DATABASE.html