### PR TITLE
feat: support Data API for provisioned Redshift clusters

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,19 @@ provider "redshift" {
 }
 ```
 
+### Authentication using Redshift Data API (provisioned cluster)
+
+```terraform
+provider "redshift" {
+  database = var.redshift_database
+  data_api {
+    cluster_identifier = var.redshift_cluster_identifier
+    username           = var.redshift_username
+    region             = var.aws_region
+  }
+}
+```
+
 ### Authentication using temporary credentials
 
 ```terraform
@@ -68,7 +81,7 @@ provider "redshift" {
 
 ### Optional
 
-- `data_api` (Block List, Max: 1) Configuration for using the Redshift Data API. This can only be used for serverless Redshift clusters. (see [below for nested schema](#nestedblock--data_api))
+- `data_api` (Block List, Max: 1) Configuration for using the Redshift Data API. Supports both serverless workgroups and provisioned clusters. (see [below for nested schema](#nestedblock--data_api))
 - `database` (String) The name of the database to connect to. The default is `redshift`.
 - `host` (String) Name of Redshift server address to connect to.
 - `max_connections` (Number) Maximum number of connections to establish to the database. Zero means unlimited.
@@ -81,13 +94,12 @@ provider "redshift" {
 <a id="nestedblock--data_api"></a>
 ### Nested Schema for `data_api`
 
-Required:
-
-- `workgroup_name` (String) The name of the Redshift Serverless workgroup to connect to.
-
 Optional:
 
-- `region` (String) The AWS region where the Redshift Serverless workgroup is located. If not specified, the region will be determined from the AWS SDK configuration.
+- `cluster_identifier` (String) The identifier of the provisioned Redshift cluster to connect to.
+- `region` (String) The AWS region where the Redshift workgroup or cluster is located.
+- `username` (String) The database user to connect as. Required at apply time when cluster_identifier is set.
+- `workgroup_name` (String) The name of the Redshift Serverless workgroup to connect to.
 
 
 <a id="nestedblock--temporary_credentials"></a>

--- a/examples/provider/provider_using_redshift_data_api_provisioned.tf
+++ b/examples/provider/provider_using_redshift_data_api_provisioned.tf
@@ -1,0 +1,8 @@
+provider "redshift" {
+  database = var.redshift_database
+  data_api {
+    cluster_identifier = var.redshift_cluster_identifier
+    username           = var.redshift_username
+    region             = var.aws_region
+  }
+}

--- a/redshift/config_data_api.go
+++ b/redshift/config_data_api.go
@@ -22,11 +22,40 @@ func buildConnStrFromDataApiConfig(workgroupName, database, awsRegion string) st
 	)
 }
 
+func NewDataApiClusterConfig(clusterIdentifier, username, database, awsRegion string, maxConns int) (*Config, error) {
+	if username == "" {
+		return nil, fmt.Errorf("data_api configuration with cluster_identifier requires username to be set")
+	}
+	connStr := buildConnStrFromDataApiClusterConfig(clusterIdentifier, username, database, awsRegion)
+	return NewConfig(redshiftDataDriverName, connStr, database, maxConns), nil
+}
+
+func buildConnStrFromDataApiClusterConfig(clusterIdentifier, username, database, awsRegion string) string {
+	return fmt.Sprintf(
+		"%s@cluster(%s)/%s?region=%s&transactionMode=non-transactional&requestMode=blocking",
+		username, clusterIdentifier, database, awsRegion,
+	)
+}
+
 func getConfigFromDataApiResourceData(d *schema.ResourceData, database string) (*Config, error) {
 	workgroupName, workgroupNameOk := d.GetOk("data_api.0.workgroup_name")
+	clusterIdentifier, clusterIdentifierOk := d.GetOk("data_api.0.cluster_identifier")
 	region, regionOk := d.GetOk("data_api.0.region")
-	if !workgroupNameOk || !regionOk {
-		return nil, fmt.Errorf("data_api configuration requires workgroup_name and region to be set")
+
+	if !regionOk {
+		return nil, fmt.Errorf("data_api configuration requires region to be set")
 	}
-	return NewDataApiConfig(workgroupName.(string), database, region.(string), 1), nil
+
+	if clusterIdentifierOk {
+		username := d.Get("data_api.0.username").(string)
+		// Data API connections are non-pooled; one connection is sufficient.
+		return NewDataApiClusterConfig(clusterIdentifier.(string), username, database, region.(string), 1)
+	}
+
+	if workgroupNameOk {
+		// Data API connections are non-pooled; one connection is sufficient.
+		return NewDataApiConfig(workgroupName.(string), database, region.(string), 1), nil
+	}
+
+	return nil, fmt.Errorf("data_api configuration requires either workgroup_name or cluster_identifier to be set")
 }

--- a/redshift/config_data_api_test.go
+++ b/redshift/config_data_api_test.go
@@ -1,0 +1,43 @@
+package redshift
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildConnStrFromDataApiClusterConfig(t *testing.T) {
+	got := buildConnStrFromDataApiClusterConfig("my-cluster", "myuser", "mydb", "us-east-1")
+	want := "myuser@cluster(my-cluster)/mydb?region=us-east-1&transactionMode=non-transactional&requestMode=blocking"
+	if got != want {
+		t.Errorf("buildConnStrFromDataApiClusterConfig() = %q, want %q", got, want)
+	}
+}
+
+func TestNewDataApiClusterConfig_MissingUsername(t *testing.T) {
+	_, err := NewDataApiClusterConfig("my-cluster", "", "mydb", "us-east-1", 1)
+	if err == nil {
+		t.Fatal("expected error when username is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "username") {
+		t.Errorf("expected error to mention 'username', got: %v", err)
+	}
+}
+
+func TestNewDataApiClusterConfig_HappyPath(t *testing.T) {
+	cfg, err := NewDataApiClusterConfig("my-cluster", "myuser", "mydb", "us-east-1", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "myuser@cluster(my-cluster)/mydb?region=us-east-1&transactionMode=non-transactional&requestMode=blocking"
+	if cfg.ConnStr != want {
+		t.Errorf("cfg.ConnStr = %q, want %q", cfg.ConnStr, want)
+	}
+}
+
+func TestBuildConnStrFromDataApiWorkgroupConfig_Unchanged(t *testing.T) {
+	got := buildConnStrFromDataApiConfig("my-workgroup", "mydb", "ap-southeast-2")
+	want := "workgroup(my-workgroup)/mydb?region=ap-southeast-2&transactionMode=non-transactional&requestMode=blocking"
+	if got != want {
+		t.Errorf("buildConnStrFromDataApiConfig() = %q, want %q", got, want)
+	}
+}

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -77,29 +77,45 @@ func Provider() *schema.Provider {
 			"data_api": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "Configuration for using the Redshift Data API. This can only be used for serverless Redshift clusters.",
+				Description: "Configuration for using the Redshift Data API. Supports both serverless workgroups and provisioned clusters.",
 				MaxItems:    1,
 				ConflictsWith: []string{
 					"host",
 					"password",
+					"temporary_credentials",
 				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"workgroup_name": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 							Description: "The name of the Redshift Serverless workgroup to connect to.",
 							DefaultFunc: schema.EnvDefaultFunc("REDSHIFT_DATA_API_SERVERLESS_WORKGROUP_NAME", nil),
-							// https://docs.aws.amazon.com/redshift-serverless/latest/APIReference/API_Workgroup.html#:~:text=Required%3A%20No-,workgroupName,-The%20name%20of
 							ValidateFunc: validation.All(
 								validation.StringLenBetween(3, 64),
 								validation.StringMatch(regexp.MustCompile("[a-z0-9-]+"), "must be lowercase alphanumeric or hyphen characters"),
 							),
+							ExactlyOneOf: []string{"data_api.0.workgroup_name", "data_api.0.cluster_identifier"},
+						},
+						"cluster_identifier": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "The identifier of the provisioned Redshift cluster to connect to.",
+							DefaultFunc:  schema.EnvDefaultFunc("REDSHIFT_DATA_API_CLUSTER_IDENTIFIER", nil),
+							ValidateFunc: validation.StringLenBetween(1, 63),
+							ExactlyOneOf: []string{"data_api.0.workgroup_name", "data_api.0.cluster_identifier"},
+						},
+						"username": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "The database user to connect as. Required at apply time when cluster_identifier is set.",
+							DefaultFunc:  schema.EnvDefaultFunc("REDSHIFT_DATA_API_USERNAME", nil),
+							ValidateFunc: validation.StringLenBetween(1, 128),
 						},
 						"region": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The AWS region where the Redshift Serverless workgroup is located. If not specified, the region will be determined from the AWS SDK configuration.",
+							Description: "The AWS region where the Redshift workgroup or cluster is located.",
 							DefaultFunc: schema.MultiEnvDefaultFunc([]string{"AWS_REGION", "AWS_DEFAULT_REGION"}, nil),
 						},
 					},
@@ -194,9 +210,12 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 func getConfigFromResourceData(d *schema.ResourceData, temporaryCredentialsResolver temporaryCredentialsResolverFunc) (*Config, error) {
 	database := d.Get("database").(string)
 	maxConnections := d.Get("max_connections").(int)
-	_, useDataApi := d.GetOk("data_api.0.workgroup_name")
+	_, useDataApiWorkgroup := d.GetOk("data_api.0.workgroup_name")
+	_, useDataApiCluster := d.GetOk("data_api.0.cluster_identifier")
+	useDataApi := useDataApiWorkgroup || useDataApiCluster
 	_, usePqResourceData := d.GetOk("host")
 
+	// Defence-in-depth: ConflictsWith in the schema already prevents this at plan time.
 	if useDataApi && usePqResourceData {
 		return nil, fmt.Errorf("using both auth methods 'data_api' and 'host' is not allowed")
 	}

--- a/redshift/provider_test.go
+++ b/redshift/provider_test.go
@@ -198,6 +198,44 @@ func Test_getConfigFromResourceData(t *testing.T) {
 			false,
 		},
 		{
+			"Data API cluster config",
+			args{
+				d: schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{
+					"database": "some-database",
+					"data_api": []interface{}{
+						map[string]interface{}{
+							"cluster_identifier": "some-cluster",
+							"username":           "some-user",
+							"region":             "us-west-2",
+						},
+					},
+				}),
+			},
+			&Config{
+				DriverName: redshiftDataDriverName,
+				ConnStr:    "some-user@cluster(some-cluster)/some-database?region=us-west-2&transactionMode=non-transactional&requestMode=blocking",
+				Database:   "some-database",
+				MaxConns:   1,
+			},
+			false,
+		},
+		{
+			"Data API cluster config - missing username",
+			args{
+				d: schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{
+					"database": "some-database",
+					"data_api": []interface{}{
+						map[string]interface{}{
+							"cluster_identifier": "some-cluster",
+							"region":             "us-west-2",
+						},
+					},
+				}),
+			},
+			nil,
+			true,
+		},
+		{
 			"PQ config",
 			args{
 				d: schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -22,6 +22,10 @@ Please note that only one authentication method can be used at a time. There is 
 
 {{ tffile "examples/provider/provider_using_redshift_data_api.tf" }}
 
+### Authentication using Redshift Data API (provisioned cluster)
+
+{{ tffile "examples/provider/provider_using_redshift_data_api_provisioned.tf" }}
+
 ### Authentication using temporary credentials
 
 {{ tffile "examples/provider/provider_using_temporary_credentials.tf" }}


### PR DESCRIPTION
## Summary

The `data_api` provider block previously only supported Redshift Serverless workgroups. This PR extends it to also support provisioned clusters via a `cluster_identifier` + `username` pair.

The underlying `redshift-data-sql-driver` already supports both DSN formats — this change wires up the provider schema and config-building logic to expose that capability.

### Changes

- New `cluster_identifier` field in `data_api` block (mutually exclusive with `workgroup_name` via `ExactlyOneOf`)
- New `username` field in `data_api` block (the DB user passed as `DbUser` in `ExecuteStatementInput`; required at apply time when `cluster_identifier` is set)
- `workgroup_name` changed from `Required` to `Optional` (schema enforces exactly one of `workgroup_name`/`cluster_identifier` must be set)
- `temporary_credentials` added to `data_api`'s `ConflictsWith` to make the conflict symmetric
- New example: `examples/provider/provider_using_redshift_data_api_provisioned.tf`

### Example usage

```hcl
provider "redshift" {
  database = "mydb"
  data_api {
    cluster_identifier = "my-cluster"
    username           = "myuser"
    region             = "us-east-1"
  }
}
```

### Testing

- Unit tests added for DSN building, happy path, missing-username error, and `ResourceData`-level schema→config wiring
- Manually tested end-to-end against a live provisioned cluster via the Data API (`create` and `destroy` of a `redshift_user`)
- Existing workgroup path unchanged (regression test included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)