### PR TITLE
fix: Remove unused SQL parameters in role-based grant queries for Data API compatibility

### DIFF
--- a/redshift/resource_redshift_grant.go
+++ b/redshift/resource_redshift_grant.go
@@ -339,14 +339,14 @@ func readTableGrants(db *DBConnection, d *schema.ResourceData) error {
   LEFT JOIN svv_relation_privileges p
     ON p.relation_name = t.table_name
     AND p.namespace_name = t.schema_name
-    AND p.identity_name = $2
+    AND p.identity_name = $1
     AND p.identity_type = 'role'
-  WHERE t.schema_name = $3
-    and t.database_name = $4
+  WHERE t.schema_name = $2
+    and t.database_name = $3
   GROUP BY t.table_name
 `
 		queryArgs = []interface{}{
-			pq.Array(grantObjectTypesCodes["table"]), entityName, schemaName, databaseName,
+			entityName, schemaName, databaseName,
 		}
 	}
 
@@ -487,11 +487,11 @@ func readCallableGrants(db *DBConnection, d *schema.ResourceData) error {
 	WHERE p.namespace_name = $1
 		AND p.identity_name = $2
 		AND p.identity_type = 'role'
-        AND pr.database_name = $4
+        AND pr.database_name = $3
 	GROUP BY p.function_name
 `
 		queryArgs = []interface{}{
-			schemaName, entityName, pq.Array(grantObjectTypesCodes[objectType]), databaseName,
+			schemaName, entityName, databaseName,
 		}
 	}
 


### PR DESCRIPTION
### Error message

"Error: execute statement: operation error Redshift Data: ExecuteStatement, https response error StatusCode: 400, RequestID: 3d3bd308-1a12-4241-9462-65f6ae9b4f03, ValidationException: Parameters list contains unused parameters. Unused parameters: [1]"

### Root Cause

Two functions had mismatches between SQL placeholders and query arguments:

**1. `readTableGrants` (role branch)**
- Query included  `pq.Array(grantObjectTypesCodes["table"])`, that was unused.

**2. `readCallableGrants` (role branch)**
- Query included `pq.Array(grantObjectTypesCodes[objectType])`, that was unused

The direct PostgreSQL driver (`lib/pq`) silently ignores unused parameters, but the Redshift Data API validates that all parameters are used and rejects queries with unused ones.

### Fix

Removed the unused `pq.Array(...)` parameters from role-based queries and renumbered the SQL placeholders accordingly:

- `readTableGrants`: `$2,$3,$4` → `$1,$2,$3`
- `readCallableGrants`: `$1,$2,$4` → `$1,$2,$3`

### Testing

- [x] Provider builds successfully
- [x] Existing functionality unchanged (user/group grants still work)
- [x] Role-based table grants now work with Data API