### PR TITLE
fix: avoid empty-string schema parameter in default privileges read

### DIFF
--- a/redshift/resource_redshift_default_privileges.go
+++ b/redshift/resource_redshift_default_privileges.go
@@ -210,7 +210,16 @@ func readGroupTableDefaultPrivileges(tx *sql.Tx, d *schema.ResourceData, ownerID
 		entityType = "role"
 	}
 
-	query = `
+	queryArgs := []interface{}{entityName, entityType, ownerID}
+	var schemaFilter string
+	if schemaNameSet {
+		schemaFilter = "AND schema_name = $4"
+		queryArgs = append(queryArgs, schemaName)
+	} else {
+		schemaFilter = "AND schema_name IS NULL"
+	}
+
+	query = fmt.Sprintf(`
 		SELECT
 			COALESCE(MAX(CASE WHEN privilege_type = 'SELECT' THEN 1 ELSE 0 END), 0) AS SELECT,
 			COALESCE(MAX(CASE WHEN privilege_type = 'UPDATE' THEN 1 ELSE 0 END), 0) AS UPDATE,
@@ -225,10 +234,10 @@ func readGroupTableDefaultPrivileges(tx *sql.Tx, d *schema.ResourceData, ownerID
 			AND grantee_name = $1
 			AND grantee_type = $2
 			AND owner_id = $3
-			AND (($4::boolean = false AND schema_name IS NULL) OR ($4::boolean = true AND schema_name = $5))
-		`
+			%s
+		`, schemaFilter)
 
-	if err := tx.QueryRow(query, entityName, entityType, ownerID, schemaNameSet, schemaName).Scan(
+	if err := tx.QueryRow(query, queryArgs...).Scan(
 		&tableSelect,
 		&tableUpdate,
 		&tableInsert,


### PR DESCRIPTION
## Summary

`readGroupTableDefaultPrivileges` always bound the schema name as a positional parameter, even when no `schema` was configured. Over a libpq connection an empty-string bind is harmless, but the **Redshift Data API** rejects any parameter whose value has length zero:

```
ValidationException: 1 validation error detected: Value '' at 'parameters.5.member.value'
failed to satisfy constraint: Member must have length greater than or equal to 1
```

This caused the post-create read of a global (schema-less) `redshift_default_privileges` resource to fail with a 400 over the Data API, leaving the resource tainted even though `ALTER DEFAULT PRIVILEGES` had already succeeded.

## Reproduction

With the provider configured to use the Data API, a schema-less (global) default privileges resource fails on the post-create read:

```hcl
provider "redshift" {
  database = "mydb"
  data_api {
    cluster_identifier = "my-cluster"
    username           = "admin"
    region             = "us-east-1"
  }
}

resource "redshift_default_privileges" "readonly_tables" {
  user        = "developer_readonly"
  owner       = "admin"
  object_type = "table"
  privileges  = ["select"]
  # no `schema` set => global default privileges => empty $5 => 400
}
```

`terraform apply`: the `ALTER DEFAULT PRIVILEGES` succeeds at the SQL level, but the read-back fails with the `ValidationException` above. Setting `schema` (binding `$5` to a non-empty value) avoids it, but only covers per-schema default privileges — there is no workaround for genuinely global default privileges over the Data API without this fix.

## Fix

Build the schema filter conditionally and only bind the schema name when it is set, so an empty-string parameter is never sent:

- `schema` set → `AND schema_name = $4` with the name bound
- `schema` unset → `AND schema_name IS NULL` with no extra parameter

The result set is identical to the previous query in both cases (the old `schema_name = $5` branch was already gated behind `$4 = true`, so the empty string was never actually evaluated against any row) — this change only stops sending the inert parameter over the wire.

## Impact

- Data API connections: global default privileges resources can now be created/read without a 400.
- libpq connections: behavior unchanged.

## Testing

This bug only manifests over the Data API (the empty-string rejection happens in the `redshift-data-sql-driver`), which the current acceptance-test suite does not exercise. Adding Data API acceptance-test coverage is tracked separately as it requires CI infrastructure for a Data-API-reachable cluster/workgroup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)