### PR TITLE
test: add Data API acceptance test for global default privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ REDSHIFT_HOST=<cluster ip or DNS>
 REDSHIFT_USER=root
 REDSHIFT_PASSWORD=<password>
 
-# Redshift Data API setup
+# Redshift Data API setup (use a serverless workgroup OR a provisioned cluster)
 AWS_REGION=eu-central-1
 REDSHIFT_DATA_API_SERVERLESS_WORKGROUP_NAME=some-workgroup
+# for a provisioned cluster instead of a serverless workgroup:
+REDSHIFT_DATA_API_CLUSTER_IDENTIFIER=some-cluster
+REDSHIFT_DATA_API_USERNAME=root
 REDSHIFT_TEST_ACC_DEBUG_REDSHIFT_DATA=true
 # optional, if the instance is not reachable through TCP/IP using the REDSHIFT_HOST env var
 REDSHIFT_TEST_ACC_SKIP_USER_LOGIN=true

--- a/redshift/acc_test.go
+++ b/redshift/acc_test.go
@@ -21,6 +21,16 @@ func getEnvOrSkip(key string, t *testing.T) string {
 	return v
 }
 
+// skipUnlessDataAPI skips the current test unless the provider is configured to
+// connect via the Redshift Data API (either a serverless workgroup or a cluster
+// identifier). Use this for tests that specifically exercise Data API behaviour.
+func skipUnlessDataAPI(t *testing.T) {
+	if os.Getenv("REDSHIFT_DATA_API_SERVERLESS_WORKGROUP_NAME") == "" &&
+		os.Getenv("REDSHIFT_DATA_API_CLUSTER_IDENTIFIER") == "" {
+		t.Skip("Skipping Data API test: set REDSHIFT_DATA_API_CLUSTER_IDENTIFIER or REDSHIFT_DATA_API_SERVERLESS_WORKGROUP_NAME to run.")
+	}
+}
+
 // Renders a string slice as a terraform array
 func tfArray(s []string) string {
 	semiformat := fmt.Sprintf("%q\n", s)

--- a/redshift/resource_redshift_default_privileges_test.go
+++ b/redshift/resource_redshift_default_privileges_test.go
@@ -120,6 +120,50 @@ func TestAccRedshiftDefaultPrivileges_Basic(t *testing.T) {
 	}
 }
 
+// TestAccRedshiftDefaultPrivileges_DataAPIGlobal is a regression test for reading
+// global (schema-less) default privileges over the Redshift Data API. The Data API
+// rejects any query parameter whose value is an empty string, so binding an unset
+// schema as a parameter previously caused the post-create read to fail with a 400
+// ValidationException even though the ALTER DEFAULT PRIVILEGES statement succeeded.
+//
+// It only runs when the provider is configured for the Data API; it is otherwise
+// identical to the schema-less user case in TestAccRedshiftDefaultPrivileges_Basic.
+func TestAccRedshiftDefaultPrivileges_DataAPIGlobal(t *testing.T) {
+	skipUnlessDataAPI(t)
+
+	userName := generateRandomObjectName("tf_acc_user")
+	rootUsername := getRootUsername()
+	config := fmt.Sprintf(`
+resource "redshift_user" "user" {
+  name     = %[1]q
+  password = "TestPassword123"
+}
+
+resource "redshift_default_privileges" "user" {
+  user        = redshift_user.user.name
+  owner       = %[2]q
+  object_type = "table"
+  privileges  = ["select"]
+}
+`, userName, rootUsername)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("redshift_default_privileges.user", "id", fmt.Sprintf("un:%s_noschema_on:%s_ot:table", userName, rootUsername)),
+					resource.TestCheckResourceAttr("redshift_default_privileges.user", "object_type", "table"),
+					resource.TestCheckResourceAttr("redshift_default_privileges.user", "privileges.#", "1"),
+					resource.TestCheckTypeSetElemAttr("redshift_default_privileges.user", "privileges.*", "select"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRedshiftDefaultPrivileges_UpdateToRevoke(t *testing.T) {
 	groupNames := []string{
 		strings.ReplaceAll(acctest.RandomWithPrefix("tf_acc_group"), "-", "_"),


### PR DESCRIPTION
## Summary

Adds `TestAccRedshiftDefaultPrivileges_DataAPIGlobal`, an acceptance test that creates a schema-less (global) `redshift_default_privileges` resource and reads it back over the **Redshift Data API** — the exact scenario fixed in #106.

The Data API rejects any query parameter whose value has length zero, so binding an unset `schema` as a parameter caused the post-create read to fail with a 400 `ValidationException`. This test guards against that regression.

> **Stacked on #106.** This branch includes the fix commit from #106, so the diff here will show both commits until #106 merges, after which it will show only the test. Please review/merge #106 first.

## What's added

- `TestAccRedshiftDefaultPrivileges_DataAPIGlobal` — schema-less global default privileges create + read.
- `skipUnlessDataAPI(t)` helper in `acc_test.go` — skips unless `REDSHIFT_DATA_API_CLUSTER_IDENTIFIER` or `REDSHIFT_DATA_API_SERVERLESS_WORKGROUP_NAME` is set. This matches the existing `getEnvOrSkip` convention, so the test is skipped during the normal libpq test run and in CI (which runs only `make test`).
- README: documents the cluster Data API env vars (`REDSHIFT_DATA_API_CLUSTER_IDENTIFIER` / `REDSHIFT_DATA_API_USERNAME`).

## Scope

This intentionally does **not** add infrastructure to spin up a Redshift cluster. It assumes ambient AWS credentials and receives connection details via the existing Data API environment variables, gating itself off when they are absent.

## Verification

Run against a provisioned cluster over the cluster Data API path:

- **Pre-fix code:** fails with `ValidationException: 1 validation error detected: Value '' at 'parameters.5.member.value' failed to satisfy constraint: Member must have length greater than or equal to 1`.
- **With #106 applied:** passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)