### PR TITLE
feat: add connect_timeout and session_parameters provider arguments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,12 +81,14 @@ provider "redshift" {
 
 ### Optional
 
+- `connect_timeout` (Number) Maximum wait for a connection to be established, in seconds. This covers the TCP connection, TLS negotiation and authentication handshake, but not the execution of individual statements. Zero applies no timeout, leaving the operating system to give up on the TCP connection in its own time. Unused when connecting via the Data API.
 - `data_api` (Block List, Max: 1) Configuration for using the Redshift Data API. Supports both serverless workgroups and provisioned clusters. (see [below for nested schema](#nestedblock--data_api))
 - `database` (String) The name of the database to connect to. The default is `redshift`.
 - `host` (String) Name of Redshift server address to connect to.
 - `max_connections` (Number) Maximum number of connections to establish to the database. Zero means unlimited.
 - `password` (String, Sensitive) Password to be used if the Redshift server demands password authentication.
 - `port` (Number) The Redshift port number to connect to at the server host.
+- `session_parameters` (Map of String) A map of session configuration parameters to apply to every connection the provider opens, sent using the libpq `options` connection parameter. Values are passed to Redshift unaltered and so use its own units. This map replaces the `PGOPTIONS` environment variable rather than merging with it. Parameter names may only contain lowercase letters, digits and underscores, and values only letters, digits and the characters `_.,:/@+-`. Cannot be combined with `data_api`, which opens a new session for each statement. See the [Amazon Redshift configuration reference](https://docs.aws.amazon.com/redshift/latest/dg/cm_chap_ConfigurationRef.html) for the list of valid parameters.
 - `sslmode` (String) This option determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the Redshift server. Valid values are `require` (default, always SSL, also skip verification), `verify-ca` (always SSL, verify that the certificate presented by the server was signed by a trusted CA), `verify-full` (always SSL, verify that the certification presented by the server was signed by a trusted CA and the server host name matches the one in the certificate), `disable` (no SSL).
 - `temporary_credentials` (Block List, Max: 1) Configuration for obtaining a temporary password using redshift:GetClusterCredentials (see [below for nested schema](#nestedblock--temporary_credentials))
 - `username` (String) Redshift user name to connect as.
@@ -131,6 +133,78 @@ Optional:
 
 - `external_id` (String) A unique identifier that might be required when you assume a role in another account.
 - `session_name` (String) An identifier for the assumed role session.
+
+## Connection Tuning
+
+```terraform
+provider "redshift" {
+  host     = var.redshift_host
+  username = var.redshift_user
+  password = var.redshift_password
+
+  # Report an error quickly when the cluster is unreachable, rather than waiting
+  # the default 180 seconds.
+  connect_timeout = 5
+
+  session_parameters = {
+    # Cancel any statement running for longer than five minutes. Redshift expresses
+    # this in milliseconds.
+    statement_timeout = "300000"
+
+    # Run provider statements in the reserved superuser queue so that they are not
+    # held up behind operational queries.
+    query_group = "superuser"
+  }
+}
+```
+
+### Connection timeouts
+
+`connect_timeout` defaults to 180 seconds, so a cluster the provider cannot reach — a
+closed security group, a disconnected VPN, a paused cluster — stalls Terraform for
+minutes before reporting an error. Connection attempts do not overlap, so a run waits for
+roughly this timeout multiplied by the number of resources Terraform has in flight. With
+the default `-parallelism=10`, `connect_timeout = 5` keeps that under a minute.
+
+When it is not set the provider reads `PGCONNECT_TIMEOUT`, so you can shorten it for a
+single run without editing your configuration; values that are not a non-negative integer
+are ignored.
+
+### Session parameters
+
+Useful parameters include:
+
+* [`statement_timeout`](https://docs.aws.amazon.com/redshift/latest/dg/r_statement_timeout.html)
+  stops any statement running longer than the given number of **milliseconds**. On Redshift
+  this budget covers planning, queueing in workload management and execution, not just
+  execution time.
+* [`query_group`](https://docs.aws.amazon.com/redshift/latest/dg/r_query_group.html) routes
+  statements to a particular workload management queue — see
+  [Query groups and the superuser queue](#query-groups-and-the-superuser-queue) below.
+
+Because these are sent using the libpq `options` connection parameter, setting
+`session_parameters` causes the `PGOPTIONS` environment variable to be ignored in its
+entirety. The provider emits a warning when both are present.
+
+### Query groups and the superuser queue
+
+Redshift routes queries to workload management queues. The statements this provider runs
+are control plane work — creating users, granting privileges, managing schemas — and are
+generally quick, but by default they share a queue with your operational queries and can
+end up waiting behind long-running ones. Setting
+[`query_group`](https://docs.aws.amazon.com/redshift/latest/dg/r_query_group.html) routes
+them somewhere else.
+
+Redshift reserves a superuser queue that sits outside your configured WLM queues, so
+provider statements sent to it are not held up by operational queries. Reaching it
+requires connecting as a superuser; for anyone else the setting has no effect on routing.
+It is the first of the
+[WLM queue assignment rules](https://docs.aws.amazon.com/redshift/latest/dg/cm-c-wlm-queue-assignment-rules.html),
+whose example configuration also shows it having a concurrency of 1. That single query
+slot means provider statements sent there run one at a time.
+
+You can also point `query_group` at a queue defined in your own WLM configuration, which
+is worth doing if you want to give provider statements dedicated concurrency and memory.
 
 ## Proxy Support
 

--- a/examples/provider/provider_with_connection_tuning.tf
+++ b/examples/provider/provider_with_connection_tuning.tf
@@ -1,0 +1,19 @@
+provider "redshift" {
+  host     = var.redshift_host
+  username = var.redshift_user
+  password = var.redshift_password
+
+  # Report an error quickly when the cluster is unreachable, rather than waiting
+  # the default 180 seconds.
+  connect_timeout = 5
+
+  session_parameters = {
+    # Cancel any statement running for longer than five minutes. Redshift expresses
+    # this in milliseconds.
+    statement_timeout = "300000"
+
+    # Run provider statements in the reserved superuser queue so that they are not
+    # held up behind operational queries.
+    query_group = "superuser"
+  }
+}

--- a/redshift/config_pq_proxy.go
+++ b/redshift/config_pq_proxy.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,22 +15,50 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	_ "github.com/lib/pq"
 )
 
 type temporaryCredentialsResolverFunc func(username string, d *schema.ResourceData) (string, string, error)
 
-func NewPqConfig(host, database, username, password string, port int, sslMode string, maxConns int) *Config {
-	connStr := buildConnStrFromPqConfig(host, database, username, password, port, sslMode)
+func NewPqConfig(host, database, username, password string, port int, sslMode string, maxConns, connectTimeout int, sessionParameters map[string]string) *Config {
+	connStr := buildConnStrFromPqConfig(host, database, username, password, port, sslMode, connectTimeout, sessionParameters)
 	return NewConfig(proxyDriverName, connStr, database, maxConns)
 }
 
-func buildConnStrFromPqConfig(host, database, username, password string, port int, sslMode string) string {
+// buildSessionParameters renders session configuration parameters into a value for the
+// libpq `options` connection parameter, which Redshift applies to the session during
+// startup. Names are sorted so that a given configuration always produces the same
+// connection string. Returns an empty string when there is nothing to set, which keeps
+// the parameter out of the connection string entirely so that PGOPTIONS still applies.
+func buildSessionParameters(sessionParameters map[string]string) string {
+	if len(sessionParameters) == 0 {
+		return ""
+	}
+
+	names := make([]string, 0, len(sessionParameters))
+	for name := range sessionParameters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("-c %s=%s", name, sessionParameters[name]))
+	}
+	return strings.Join(parts, " ")
+}
+
+func buildConnStrFromPqConfig(host, database, username, password string, port int, sslMode string, connectTimeout int, sessionParameters map[string]string) string {
 	params := map[string]string{}
 
 	params["sslmode"] = sslMode
-	params["connect_timeout"] = "180"
+	params["connect_timeout"] = strconv.Itoa(connectTimeout)
+	if renderedParameters := buildSessionParameters(sessionParameters); renderedParameters != "" {
+		params["options"] = renderedParameters
+	}
 
 	var paramsArray []string
 	for key, value := range params {
@@ -49,12 +78,16 @@ func buildConnStrFromPqConfig(host, database, username, password string, port in
 }
 
 func getConfigFromPqResourceData(d *schema.ResourceData, database string, maxConnections int, temporaryCredentialsResolver temporaryCredentialsResolverFunc) (*Config, error) {
-	var err error
 	var password string
 	host := d.Get("host").(string)
 	username := d.Get("username").(string)
 	port := d.Get("port").(int)
 	sslMode := d.Get("sslmode").(string)
+	connectTimeout := d.Get("connect_timeout").(int)
+	sessionParameters, err := sessionParametersFromResourceData(d)
+	if err != nil {
+		return nil, err
+	}
 	log.Printf("[DEBUG] using username %q for authentication\n", username)
 	_, useTemporaryCredentials := d.GetOk("temporary_credentials")
 	if useTemporaryCredentials {
@@ -68,7 +101,63 @@ func getConfigFromPqResourceData(d *schema.ResourceData, database string, maxCon
 		log.Println("[DEBUG] using password authentication")
 		password = d.Get("password").(string)
 	}
-	return NewPqConfig(host, database, username, password, port, sslMode, maxConnections), nil
+	return NewPqConfig(host, database, username, password, port, sslMode, maxConnections, connectTimeout, sessionParameters), nil
+}
+
+// sessionParametersFromResourceData reads and validates the `session_parameters` provider
+// argument.
+func sessionParametersFromResourceData(d *schema.ResourceData) (map[string]string, error) {
+	raw, ok := d.GetOk("session_parameters")
+	if !ok {
+		return nil, nil
+	}
+
+	sessionParameters := map[string]string{}
+	for name, value := range raw.(map[string]interface{}) {
+		stringValue := value.(string)
+		if err := validateSessionParameter(name, stringValue); err != nil {
+			return nil, err
+		}
+		sessionParameters[name] = stringValue
+	}
+	return sessionParameters, nil
+}
+
+func validateSessionParameter(name, value string) error {
+	if err := validateSessionParameterName(name); err != nil {
+		return err
+	}
+	if !sessionParameterValueRegexp.MatchString(value) {
+		return fmt.Errorf("invalid value %q for session parameter %q: only letters, digits and the characters _.,:/@+- are allowed", value, name)
+	}
+	return nil
+}
+
+// validateSessionParameters reports invalid parameters during validation rather than
+// waiting until the provider is configured, so that the diagnostic carries the attribute
+// path and `terraform validate` rejects the configuration.
+func validateSessionParameters(value interface{}, path cty.Path) diag.Diagnostics {
+	sessionParameters, ok := value.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	var diags diag.Diagnostics
+	for name, raw := range sessionParameters {
+		stringValue, isString := raw.(string)
+		if !isString {
+			continue
+		}
+		if err := validateSessionParameter(name, stringValue); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       "Invalid session parameter",
+				Detail:        err.Error(),
+				AttributePath: append(path, cty.IndexStep{Key: cty.StringVal(name)}),
+			})
+		}
+	}
+	return diags
 }
 
 // temporaryCredentials gets temporary credentials using GetClusterCredentials

--- a/redshift/config_pq_proxy_test.go
+++ b/redshift/config_pq_proxy_test.go
@@ -1,0 +1,584 @@
+package redshift
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/lib/pq"
+)
+
+func TestBuildSessionParameters(t *testing.T) {
+	tests := []struct {
+		name    string
+		options map[string]string
+		want    string
+	}{
+		{
+			name:    "nil map produces no options",
+			options: nil,
+			want:    "",
+		},
+		{
+			name:    "empty map produces no options",
+			options: map[string]string{},
+			want:    "",
+		},
+		{
+			name:    "single option",
+			options: map[string]string{"statement_timeout": "30000"},
+			want:    "-c statement_timeout=30000",
+		},
+		{
+			name:    "multiple options are sorted by name",
+			options: map[string]string{"query_group": "superuser", "statement_timeout": "30000", "application_name": "terraform"},
+			want:    "-c application_name=terraform -c query_group=superuser -c statement_timeout=30000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildSessionParameters(tt.options); got != tt.want {
+				t.Errorf("buildSessionParameters() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildConnStrFromPqConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		connectTimeout int
+		options        map[string]string
+		want           string
+	}{
+		{
+			name:           "no options omits the parameter entirely",
+			connectTimeout: 180,
+			options:        nil,
+			want:           "postgres://myuser:mypassword@redshift.example.com:5439/mydb?connect_timeout=180&sslmode=require",
+		},
+		{
+			name:           "connect timeout is configurable",
+			connectTimeout: 15,
+			options:        nil,
+			want:           "postgres://myuser:mypassword@redshift.example.com:5439/mydb?connect_timeout=15&sslmode=require",
+		},
+		{
+			name:           "zero connect timeout applies no timeout",
+			connectTimeout: 0,
+			options:        nil,
+			want:           "postgres://myuser:mypassword@redshift.example.com:5439/mydb?connect_timeout=0&sslmode=require",
+		},
+		{
+			name:           "options are escaped into the connection string",
+			connectTimeout: 180,
+			options:        map[string]string{"query_group": "superuser", "statement_timeout": "30000"},
+			want:           "postgres://myuser:mypassword@redshift.example.com:5439/mydb?connect_timeout=180&options=-c+query_group%3Dsuperuser+-c+statement_timeout%3D30000&sslmode=require",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildConnStrFromPqConfig("redshift.example.com", "mydb", "myuser", "mypassword", 5439, "require", tt.connectTimeout, tt.options)
+			if got != tt.want {
+				t.Errorf("buildConnStrFromPqConfig() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The connection string is URL encoded, but lib/pq decodes it into its own configuration
+// before connecting. Session parameters survive that conversion with their spaces intact.
+func TestBuildConnStrFromPqConfigSurvivesPqParsing(t *testing.T) {
+	unsetAndSetEnvVars(t, "PGCONNECT_TIMEOUT", "PGOPTIONS")
+	connStr := buildConnStrFromPqConfig("redshift.example.com", "mydb", "myuser", "mypassword", 5439, "require", 15, map[string]string{
+		"query_group":       "superuser",
+		"statement_timeout": "30000",
+	})
+
+	cfg, err := pq.NewConfig(connStr)
+	if err != nil {
+		t.Fatalf("pq.NewConfig() returned an unexpected error: %v", err)
+	}
+
+	want := "-c query_group=superuser -c statement_timeout=30000"
+	if cfg.Options != want {
+		t.Errorf("cfg.Options = %q, want %q", cfg.Options, want)
+	}
+	if cfg.ConnectTimeout != 15*time.Second {
+		t.Errorf("cfg.ConnectTimeout = %v, want %v", cfg.ConnectTimeout, 15*time.Second)
+	}
+}
+
+// PGOPTIONS applies only while the provider sends no options of its own, because lib/pq
+// lets the connection string take precedence over the environment.
+func TestBuildConnStrFromPqConfigLeavesPGOptionsAloneWhenUnset(t *testing.T) {
+	unsetAndSetEnvVars(t, "PGCONNECT_TIMEOUT")
+	t.Setenv("PGOPTIONS", "-c search_path=someschema")
+
+	connStr := buildConnStrFromPqConfig("redshift.example.com", "mydb", "myuser", "mypassword", 5439, "require", 15, nil)
+	cfg, err := pq.NewConfig(connStr)
+	if err != nil {
+		t.Fatalf("pq.NewConfig() returned an unexpected error: %v", err)
+	}
+	if cfg.Options != "-c search_path=someschema" {
+		t.Errorf("cfg.Options = %q, want the value from PGOPTIONS", cfg.Options)
+	}
+
+	connStr = buildConnStrFromPqConfig("redshift.example.com", "mydb", "myuser", "mypassword", 5439, "require", 15, map[string]string{"query_group": "superuser"})
+	cfg, err = pq.NewConfig(connStr)
+	if err != nil {
+		t.Fatalf("pq.NewConfig() returned an unexpected error: %v", err)
+	}
+	if cfg.Options != "-c query_group=superuser" {
+		t.Errorf("cfg.Options = %q, want the configured options to replace PGOPTIONS", cfg.Options)
+	}
+}
+
+func TestWarnOnShadowedPGOptions(t *testing.T) {
+	unsetAndSetEnvVars(t, "PGCONNECT_TIMEOUT")
+	tests := []struct {
+		name      string
+		pgOptions string
+		options   map[string]interface{}
+		wantWarn  bool
+	}{
+		{name: "neither set"},
+		{name: "only PGOPTIONS set", pgOptions: "-c search_path=someschema"},
+		{name: "only options set", options: map[string]interface{}{"query_group": "superuser"}},
+		{
+			name:      "both set",
+			pgOptions: "-c search_path=someschema",
+			options:   map[string]interface{}{"query_group": "superuser"},
+			wantWarn:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PGOPTIONS", tt.pgOptions)
+
+			raw := map[string]interface{}{}
+			if tt.options != nil {
+				raw["session_parameters"] = tt.options
+			}
+			d := schema.TestResourceDataRaw(t, Provider().Schema, raw)
+
+			diags := warnOnShadowedPGOptions(d)
+			if tt.wantWarn {
+				if len(diags) != 1 || diags[0].Severity != diag.Warning {
+					t.Fatalf("expected exactly one warning, got %#v", diags)
+				}
+				return
+			}
+			if len(diags) != 0 {
+				t.Errorf("expected no diagnostics, got %#v", diags)
+			}
+		})
+	}
+}
+
+// connect_timeout carries a DefaultFunc, which the SDK treats as the argument always
+// being set. Declaring a conflict against data_api would therefore reject every Data API
+// configuration.
+func TestDataApiConfigurationHasNoConflicts(t *testing.T) {
+	unsetAndSetEnvVars(t, "AWS_REGION", "AWS_DEFAULT_REGION", "REDSHIFT_HOST", "PGCONNECT_TIMEOUT")
+
+	raw := map[string]interface{}{
+		"data_api": []interface{}{map[string]interface{}{
+			"workgroup_name": "my-workgroup",
+			"region":         "us-west-2",
+		}},
+	}
+
+	for _, d := range Provider().Validate(terraform.NewResourceConfigRaw(raw)) {
+		t.Errorf("unexpected diagnostic: %s: %s (path %v)", d.Summary, d.Detail, d.AttributePath)
+	}
+}
+
+func TestSessionParametersConflictWithDataApi(t *testing.T) {
+	unsetAndSetEnvVars(t, "AWS_REGION", "AWS_DEFAULT_REGION", "REDSHIFT_HOST", "PGCONNECT_TIMEOUT")
+
+	raw := map[string]interface{}{
+		"data_api": []interface{}{map[string]interface{}{
+			"workgroup_name": "my-workgroup",
+			"region":         "us-west-2",
+		}},
+		"session_parameters": map[string]interface{}{"query_group": "superuser"},
+	}
+
+	diags := Provider().Validate(terraform.NewResourceConfigRaw(raw))
+	var found bool
+	for _, d := range diags {
+		if strings.Contains(d.Summary, "Conflicting configuration arguments") && strings.Contains(d.Detail, "session_parameters") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a conflict naming options, got %#v", diags)
+	}
+}
+
+// PGCONNECT_TIMEOUT is read for every configuration, including Data API ones that never
+// open a libpq connection, so a value that cannot be used must not reject the provider.
+func TestUnusableConnectTimeoutEnvIsIgnored(t *testing.T) {
+	for _, value := range []string{"10s", "abc", "1.5", " 30", "-5", "300000000000000000000"} {
+		t.Run(value, func(t *testing.T) {
+			unsetAndSetEnvVars(t, "AWS_REGION", "AWS_DEFAULT_REGION", "REDSHIFT_HOST")
+			t.Setenv("PGCONNECT_TIMEOUT", value)
+
+			raw := map[string]interface{}{
+				"data_api": []interface{}{map[string]interface{}{
+					"workgroup_name": "my-workgroup",
+					"region":         "us-west-2",
+				}},
+			}
+			for _, d := range Provider().Validate(terraform.NewResourceConfigRaw(raw)) {
+				t.Errorf("data_api configuration rejected: %s: %s", d.Summary, d.Detail)
+			}
+
+			d := schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{"host": "redshift.example.com"})
+			if got := d.Get("connect_timeout").(int); got != defaultConnectTimeoutInSeconds {
+				t.Errorf("connect_timeout = %d, want the default %d", got, defaultConnectTimeoutInSeconds)
+			}
+		})
+	}
+}
+
+// A negative timeout would disable the timeout entirely in lib/pq, which is the opposite
+// of what anyone setting it intends.
+func TestNegativeConnectTimeoutIsRejected(t *testing.T) {
+	unsetAndSetEnvVars(t, "AWS_REGION", "AWS_DEFAULT_REGION", "REDSHIFT_HOST", "PGCONNECT_TIMEOUT")
+
+	raw := map[string]interface{}{"host": "redshift.example.com", "connect_timeout": -1}
+	diags := Provider().Validate(terraform.NewResourceConfigRaw(raw))
+	if len(diags) == 0 {
+		t.Fatal("expected connect_timeout = -1 to be rejected, got no diagnostics")
+	}
+}
+
+// Invalid options must fail `terraform validate`, with the diagnostic pointing at the
+// offending key rather than surfacing later as an untargeted provider error.
+func TestInvalidSessionParametersFailValidation(t *testing.T) {
+	unsetAndSetEnvVars(t, "AWS_REGION", "AWS_DEFAULT_REGION", "REDSHIFT_HOST", "PGCONNECT_TIMEOUT")
+
+	raw := map[string]interface{}{
+		"host":               "redshift.example.com",
+		"session_parameters": map[string]interface{}{"query_group": "bad value"},
+	}
+	diags := Provider().Validate(terraform.NewResourceConfigRaw(raw))
+	if len(diags) == 0 {
+		t.Fatal("expected invalid options to be rejected at validate time, got no diagnostics")
+	}
+	if !strings.Contains(diags[0].Detail, "query_group") {
+		t.Errorf("diagnostic does not name the offending option: %#v", diags[0])
+	}
+	if len(diags[0].AttributePath) == 0 {
+		t.Errorf("diagnostic carries no attribute path: %#v", diags[0])
+	}
+}
+
+// The error from reading options must reach the caller rather than being dropped, or an
+// invalid configuration would connect with the options silently discarded.
+func TestInvalidSessionParametersFailProviderConfiguration(t *testing.T) {
+	unsetAndSetEnvVars(t, "AWS_REGION", "AWS_DEFAULT_REGION", "REDSHIFT_HOST", "PGCONNECT_TIMEOUT")
+
+	d := schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{
+		"host":               "redshift.example.com",
+		"session_parameters": map[string]interface{}{"query_group": "bad value"},
+	})
+	if _, err := getConfigFromResourceData(d, nil); err == nil {
+		t.Fatal("expected an error for an invalid session parameter, got nil")
+	}
+}
+
+// The warning must be wired into provider configuration, not merely available.
+func TestProviderConfigureWarnsAboutShadowedPGOptions(t *testing.T) {
+	unsetAndSetEnvVars(t, "AWS_REGION", "AWS_DEFAULT_REGION", "REDSHIFT_HOST", "PGCONNECT_TIMEOUT")
+	t.Setenv("PGOPTIONS", "-c search_path=someschema")
+
+	d := schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{
+		"host":               "redshift.example.com",
+		"session_parameters": map[string]interface{}{"query_group": "superuser"},
+	})
+
+	_, diags := providerConfigure(context.Background(), d)
+	var found bool
+	for _, diagnostic := range diags {
+		if diagnostic.Severity == diag.Warning && strings.Contains(diagnostic.Summary, "PGOPTIONS") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a PGOPTIONS warning from providerConfigure, got %#v", diags)
+	}
+}
+
+// An explicitly configured argument takes precedence over the libpq environment variable
+// that supplies its default, and over the environment variable lib/pq reads for itself.
+func TestExplicitConfigurationBeatsEnvironment(t *testing.T) {
+	tests := []struct {
+		name              string
+		pgConnectTimeout  string
+		pgOptions         string
+		config            map[string]interface{}
+		wantConnectTimout string
+		wantOptions       string
+	}{
+		{
+			name:              "neither configured nor in the environment",
+			config:            map[string]interface{}{},
+			wantConnectTimout: "180",
+		},
+		{
+			name:              "environment only",
+			pgConnectTimeout:  "30",
+			config:            map[string]interface{}{},
+			wantConnectTimout: "30",
+		},
+		{
+			name:              "explicit connect_timeout overrides the environment",
+			pgConnectTimeout:  "30",
+			config:            map[string]interface{}{"connect_timeout": 7},
+			wantConnectTimout: "7",
+		},
+		{
+			name:              "explicit options override PGOPTIONS",
+			pgOptions:         "-c search_path=someschema",
+			config:            map[string]interface{}{"session_parameters": map[string]interface{}{"query_group": "superuser"}},
+			wantConnectTimout: "180",
+			wantOptions:       "-c query_group=superuser",
+		},
+		{
+			name:              "explicit values for both override both variables",
+			pgConnectTimeout:  "30",
+			pgOptions:         "-c search_path=someschema",
+			config:            map[string]interface{}{"connect_timeout": 7, "session_parameters": map[string]interface{}{"query_group": "superuser"}},
+			wantConnectTimout: "7",
+			wantOptions:       "-c query_group=superuser",
+		},
+		{
+			name:              "PGOPTIONS still applies when options is not configured",
+			pgOptions:         "-c search_path=someschema",
+			config:            map[string]interface{}{},
+			wantConnectTimout: "180",
+			wantOptions:       "-c search_path=someschema",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetAndSetEnvVars(t, "PGCONNECT_TIMEOUT", "PGOPTIONS")
+			if tt.pgConnectTimeout != "" {
+				t.Setenv("PGCONNECT_TIMEOUT", tt.pgConnectTimeout)
+			}
+			if tt.pgOptions != "" {
+				t.Setenv("PGOPTIONS", tt.pgOptions)
+			}
+
+			raw := map[string]interface{}{"host": "redshift.example.com", "username": "myuser", "database": "mydb"}
+			for key, value := range tt.config {
+				raw[key] = value
+			}
+			d := schema.TestResourceDataRaw(t, Provider().Schema, raw)
+
+			config, err := getConfigFromPqResourceData(d, "mydb", 20, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Reading the connection string back the way lib/pq does proves the value the
+			// server will actually be given, including which source won.
+			cfg, err := pq.NewConfig(config.ConnStr)
+			if err != nil {
+				t.Fatalf("pq.NewConfig() returned an unexpected error: %v", err)
+			}
+
+			wantTimeout, _ := strconv.Atoi(tt.wantConnectTimout)
+			if cfg.ConnectTimeout != time.Duration(wantTimeout)*time.Second {
+				t.Errorf("ConnectTimeout = %v, want %vs", cfg.ConnectTimeout, wantTimeout)
+			}
+			if cfg.Options != tt.wantOptions {
+				t.Errorf("Options = %q, want %q", cfg.Options, tt.wantOptions)
+			}
+		})
+	}
+}
+
+func TestSessionParametersFromResourceData(t *testing.T) {
+	unsetAndSetEnvVars(t, "PGCONNECT_TIMEOUT")
+	tests := []struct {
+		name        string
+		options     map[string]interface{}
+		want        map[string]string
+		wantErrPart string
+	}{
+		{
+			name:    "unset",
+			options: nil,
+			want:    nil,
+		},
+		{
+			name:    "valid options",
+			options: map[string]interface{}{"statement_timeout": "30000", "query_group": "superuser"},
+			want:    map[string]string{"statement_timeout": "30000", "query_group": "superuser"},
+		},
+		{
+			name:    "empty map behaves as unset",
+			options: map[string]interface{}{},
+			want:    nil,
+		},
+		{
+			name:        "uppercase name is rejected",
+			options:     map[string]interface{}{"Statement_Timeout": "30000"},
+			wantErrPart: "invalid session parameter name",
+		},
+		{
+			name:        "name containing a hyphen is rejected",
+			options:     map[string]interface{}{"statement-timeout": "30000"},
+			wantErrPart: "invalid session parameter name",
+		},
+		{
+			name:        "name injecting another argument is rejected",
+			options:     map[string]interface{}{"query_group=x -c statement_timeout": "1"},
+			wantErrPart: "invalid session parameter name",
+		},
+		{
+			name:        "value injecting another argument is rejected",
+			options:     map[string]interface{}{"query_group": "x -c statement_timeout=1"},
+			wantErrPart: "invalid value",
+		},
+		{
+			name:        "value containing a quote is rejected",
+			options:     map[string]interface{}{"query_group": "x'y"},
+			wantErrPart: "invalid value",
+		},
+		{
+			name:        "value containing a backslash is rejected",
+			options:     map[string]interface{}{"query_group": `x\y`},
+			wantErrPart: "invalid value",
+		},
+		// Redshift splits the argument list with isspace(), which treats vertical tab and
+		// form feed as separators just like space and tab.
+		{
+			name:        "value containing a vertical tab is rejected",
+			options:     map[string]interface{}{"query_group": "x\v-c\vstatement_timeout=1"},
+			wantErrPart: "invalid value",
+		},
+		{
+			name:        "value containing a form feed is rejected",
+			options:     map[string]interface{}{"query_group": "x\f-c\fstatement_timeout=1"},
+			wantErrPart: "invalid value",
+		},
+		// lib/pq writes options as a NUL terminated protocol string, so an embedded NUL
+		// would silently discard every option sorting after this one.
+		{
+			name:        "value containing a NUL is rejected",
+			options:     map[string]interface{}{"query_group": "x\x00y"},
+			wantErrPart: "invalid value",
+		},
+		{
+			name:        "empty value is rejected",
+			options:     map[string]interface{}{"query_group": ""},
+			wantErrPart: "invalid value",
+		},
+		{
+			name:    "values may contain punctuation Redshift settings use",
+			options: map[string]interface{}{"search_path": "public,other_schema", "timezone": "America/New_York"},
+			want:    map[string]string{"search_path": "public,other_schema", "timezone": "America/New_York"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := map[string]interface{}{}
+			if tt.options != nil {
+				raw["session_parameters"] = tt.options
+			}
+			d := schema.TestResourceDataRaw(t, Provider().Schema, raw)
+
+			got, err := sessionParametersFromResourceData(d)
+			if tt.wantErrPart != "" {
+				if err == nil {
+					t.Fatalf("expected an error containing %q, got nil", tt.wantErrPart)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrPart) {
+					t.Errorf("error = %v, want it to contain %q", err, tt.wantErrPart)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d options, want %d (got %v)", len(got), len(tt.want), got)
+			}
+			for key, want := range tt.want {
+				if got[key] != want {
+					t.Errorf("option %q = %q, want %q", key, got[key], want)
+				}
+			}
+		})
+	}
+}
+
+// TestAccSessionParametersAreApplied verifies against a real cluster that session parameters
+// reach the server. They travel in the libpq `options` startup parameter so that they
+// apply to each connection as it is made: the provider keeps no idle connections, so a
+// `SET` issued after connecting would not be seen by later statements.
+func TestAccSessionParametersAreApplied(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set. Skipping acceptance test...")
+	}
+	host := getEnvOrSkip("REDSHIFT_HOST", t)
+	username := getEnvOrSkip("REDSHIFT_USER", t)
+	password := os.Getenv("REDSHIFT_PASSWORD")
+
+	port := 5439
+	if v := os.Getenv("REDSHIFT_PORT"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			t.Fatalf("bad REDSHIFT_PORT: %v", err)
+		}
+		port = parsed
+	}
+	database := os.Getenv("REDSHIFT_DATABASE")
+	if database == "" {
+		database = "redshift"
+	}
+	sslMode := os.Getenv("REDSHIFT_SSLMODE")
+	if sslMode == "" {
+		sslMode = "require"
+	}
+
+	config := NewPqConfig(host, database, username, password, port, sslMode, 1, 30, map[string]string{
+		"statement_timeout": "31000",
+		"query_group":       "terraform_acc_test",
+	})
+
+	db, err := config.NewClient().Connect()
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+
+	for setting, want := range map[string]string{
+		"statement_timeout": "31000",
+		"query_group":       "terraform_acc_test",
+	} {
+		var got string
+		if err := db.QueryRow(fmt.Sprintf("SHOW %s", setting)).Scan(&got); err != nil {
+			t.Fatalf("failed to read %s: %v", setting, err)
+		}
+		if got != want {
+			t.Errorf("%s = %q, want %q", setting, got, want)
+		}
+	}
+}

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -15,6 +17,7 @@ import (
 const (
 	defaultProviderMaxOpenConnections                      = 20
 	defaultTemporaryCredentialsAssumeRoleDurationInSeconds = 900
+	defaultConnectTimeoutInSeconds                         = 180
 )
 
 func Provider() *schema.Provider {
@@ -74,6 +77,25 @@ func Provider() *schema.Provider {
 				Description:  "Maximum number of connections to establish to the database. Zero means unlimited.",
 				ValidateFunc: validation.IntAtLeast(-1),
 			},
+			// connect_timeout deliberately declares no ConflictsWith. Its DefaultFunc always
+			// returns a value, which the SDK treats as the argument being set, so a conflict
+			// would fire for every data_api user. Like port and sslmode, it is simply unused
+			// by the Data API transport.
+			"connect_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				DefaultFunc:  connectTimeoutDefault,
+				Description:  "Maximum wait for a connection to be established, in seconds. This covers the TCP connection, TLS negotiation and authentication handshake, but not the execution of individual statements. Zero applies no timeout, leaving the operating system to give up on the TCP connection in its own time. Unused when connecting via the Data API.",
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"session_parameters": {
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				Description:      "A map of session configuration parameters to apply to every connection the provider opens, sent using the libpq `options` connection parameter. Values are passed to Redshift unaltered and so use its own units. This map replaces the `PGOPTIONS` environment variable rather than merging with it. Parameter names may only contain lowercase letters, digits and underscores, and values only letters, digits and the characters `_.,:/@+-`. Cannot be combined with `data_api`, which opens a new session for each statement. See the [Amazon Redshift configuration reference](https://docs.aws.amazon.com/redshift/latest/dg/cm_chap_ConfigurationRef.html) for the list of valid parameters.",
+				ConflictsWith:    []string{"data_api"},
+				ValidateDiagFunc: validateSessionParameters,
+			},
 			"data_api": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -83,6 +105,7 @@ func Provider() *schema.Provider {
 					"host",
 					"password",
 					"temporary_credentials",
+					"session_parameters",
 				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -196,16 +219,56 @@ func Provider() *schema.Provider {
 	}
 }
 
+// connectTimeoutDefault resolves the default from PGCONNECT_TIMEOUT, the variable libpq
+// itself reads. A value that is not a non-negative integer falls back to the built-in
+// default rather than failing: the argument is also present for Data API configurations,
+// which never open a libpq connection and must not be broken by an unrelated variable in
+// the environment. lib/pq reports the bad value, naming the variable, if a libpq
+// connection is actually made.
+func connectTimeoutDefault() (interface{}, error) {
+	raw := os.Getenv("PGCONNECT_TIMEOUT")
+	if raw == "" {
+		return defaultConnectTimeoutInSeconds, nil
+	}
+	seconds, err := strconv.Atoi(raw)
+	if err != nil || seconds < 0 {
+		log.Printf("[WARN] ignoring PGCONNECT_TIMEOUT value %q: not a non-negative integer", raw)
+		return defaultConnectTimeoutInSeconds, nil
+	}
+	return seconds, nil
+}
+
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	cfg, err := getConfigFromResourceData(d, temporaryCredentials)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
 
+	diags := warnOnShadowedPGOptions(d)
+
 	log.Println("[DEBUG] creating database client")
 	client := cfg.NewClient()
 	log.Println("[DEBUG] created database client")
-	return client, nil
+	return client, diags
+}
+
+// warnOnShadowedPGOptions reports that PGOPTIONS is being discarded. Session parameters
+// are sent as the libpq `options` connection parameter, which takes precedence over the
+// environment variable of the same meaning, so a user setting both silently loses the
+// settings from their environment.
+func warnOnShadowedPGOptions(d *schema.ResourceData) diag.Diagnostics {
+	sessionParameters, ok := d.GetOk("session_parameters")
+	if !ok || len(sessionParameters.(map[string]interface{})) == 0 {
+		return nil
+	}
+	if os.Getenv("PGOPTIONS") == "" {
+		return nil
+	}
+	return diag.Diagnostics{{
+		Severity: diag.Warning,
+		Summary:  "PGOPTIONS is ignored",
+		Detail:   "The provider's `session_parameters` argument is set, which overrides the PGOPTIONS environment variable in its entirety. Move any settings you still need from PGOPTIONS into `session_parameters`.",
+	}}
 }
 
 func getConfigFromResourceData(d *schema.ResourceData, temporaryCredentialsResolver temporaryCredentialsResolverFunc) (*Config, error) {

--- a/redshift/provider_test.go
+++ b/redshift/provider_test.go
@@ -162,7 +162,7 @@ func prepareRedshiftTemporaryCredentialsTestCases(t *testing.T, provider *schema
 }
 
 func Test_getConfigFromResourceData(t *testing.T) {
-	unsetAndSetEnvVars(t, "AWS_REGION", "AWS_DEFAULT_REGION", "REDSHIFT_HOST")
+	unsetAndSetEnvVars(t, "AWS_REGION", "AWS_DEFAULT_REGION", "REDSHIFT_HOST", "PGCONNECT_TIMEOUT", "PGOPTIONS")
 	type args struct {
 		d *schema.ResourceData
 	}

--- a/redshift/resource_redshift_user_test.go
+++ b/redshift/resource_redshift_user_test.go
@@ -663,7 +663,7 @@ func testAccCheckRedshiftUserCanLogin(user string, password string) resource.Tes
 			sslMode = "require"
 		}
 		config := NewPqConfig(os.Getenv("REDSHIFT_HOST"), database, user, password, portNum, sslMode,
-			defaultProviderMaxOpenConnections)
+			defaultProviderMaxOpenConnections, defaultConnectTimeoutInSeconds, nil)
 
 		client := config.NewClient()
 		if err != nil {

--- a/redshift/validation.go
+++ b/redshift/validation.go
@@ -178,5 +178,13 @@ var dbGroupValidate = validation.All(
 	validation.StringNotInSlice(reservedWords, true),
 )
 
+// Session parameter values are interpolated into the whitespace-separated argument list
+// carried by the libpq `options` connection parameter. Redshift splits that list using
+// isspace(), which covers vertical tab and form feed as well as space and tab, so the
+// permitted characters are listed inclusively rather than by excluding the separators
+// known today. A value can then never introduce an argument of its own.
+// See https://docs.aws.amazon.com/redshift/latest/dg/cm_chap_ConfigurationRef.html
+var sessionParameterValueRegexp = regexp.MustCompile(`^[A-Za-z0-9_.,:/@+-]+$`)
+
 var awsAccountIdRegexp = regexp.MustCompile(`^\d{12}$`)
 var uuidRegex = regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -36,6 +36,58 @@ Please note that only one authentication method can be used at a time. There is 
 
 {{ .SchemaMarkdown | trimspace }}
 
+## Connection Tuning
+
+{{ tffile "examples/provider/provider_with_connection_tuning.tf" }}
+
+### Connection timeouts
+
+`connect_timeout` defaults to 180 seconds, so a cluster the provider cannot reach — a
+closed security group, a disconnected VPN, a paused cluster — stalls Terraform for
+minutes before reporting an error. Connection attempts do not overlap, so a run waits for
+roughly this timeout multiplied by the number of resources Terraform has in flight. With
+the default `-parallelism=10`, `connect_timeout = 5` keeps that under a minute.
+
+When it is not set the provider reads `PGCONNECT_TIMEOUT`, so you can shorten it for a
+single run without editing your configuration; values that are not a non-negative integer
+are ignored.
+
+### Session parameters
+
+Useful parameters include:
+
+* [`statement_timeout`](https://docs.aws.amazon.com/redshift/latest/dg/r_statement_timeout.html)
+  stops any statement running longer than the given number of **milliseconds**. On Redshift
+  this budget covers planning, queueing in workload management and execution, not just
+  execution time.
+* [`query_group`](https://docs.aws.amazon.com/redshift/latest/dg/r_query_group.html) routes
+  statements to a particular workload management queue — see
+  [Query groups and the superuser queue](#query-groups-and-the-superuser-queue) below.
+
+Because these are sent using the libpq `options` connection parameter, setting
+`session_parameters` causes the `PGOPTIONS` environment variable to be ignored in its
+entirety. The provider emits a warning when both are present.
+
+### Query groups and the superuser queue
+
+Redshift routes queries to workload management queues. The statements this provider runs
+are control plane work — creating users, granting privileges, managing schemas — and are
+generally quick, but by default they share a queue with your operational queries and can
+end up waiting behind long-running ones. Setting
+[`query_group`](https://docs.aws.amazon.com/redshift/latest/dg/r_query_group.html) routes
+them somewhere else.
+
+Redshift reserves a superuser queue that sits outside your configured WLM queues, so
+provider statements sent to it are not held up by operational queries. Reaching it
+requires connecting as a superuser; for anyone else the setting has no effect on routing.
+It is the first of the
+[WLM queue assignment rules](https://docs.aws.amazon.com/redshift/latest/dg/cm-c-wlm-queue-assignment-rules.html),
+whose example configuration also shows it having a concurrency of 1. That single query
+slot means provider statements sent there run one at a time.
+
+You can also point `query_group` at a queue defined in your own WLM configuration, which
+is worth doing if you want to give provider statements dedicated concurrency and memory.
+
 ## Proxy Support
 
 If your Redshift cluster is only accessible from within a VPC, you can use the `ALL_PROXY` (`all_proxy`)


### PR DESCRIPTION
## Summary

Allows configuration of `connect_timeout`, and adds `session_parameters`, both in the provider configuration. `connect_timeout` was previously hardcoded to 180 seconds in the connection string, so an unreachable cluster stalled Terraform for minutes with no way to shorten the wait.

```hcl
provider "redshift" {
  host     = var.redshift_host
  username = var.redshift_user
  password = var.redshift_password

  connect_timeout = 5

  session_parameters = {
    statement_timeout = "300000"
    query_group       = "superuser"
  }
}
```

## Behavior

- `connect_timeout` keeps the existing default of 180 seconds, so upgrading changes nothing. It takes its default from `PGCONNECT_TIMEOUT` when unset.
- `session_parameters` is sent as the libpq `options` connection parameter and so replaces `PGOPTIONS` rather than merging with it; the provider warns when both are set. When unset, the parameter is omitted from the connection string entirely so `PGOPTIONS` continues to apply.
- Both arguments document themselves in the provider schema. The provider doc page adds a Connection Tuning section covering the two session parameters most likely to be wanted, `statement_timeout` and `query_group`, including routing provider statements to a WLM queue.

## Implementation notes

- Session parameters travel in the `options` **startup** parameter rather than being applied with `SET` after connecting, because `Client.Connect` sets `SetMaxIdleConns(0)`. No session is ever reused, so a `SET` would not be seen by later statements.
- `connect_timeout` deliberately declares no `ConflictsWith`. Its `DefaultFunc` always returns a value, which the SDK treats as the argument being set, so a conflict against `data_api` would reject every Data API configuration. For the same reason an unusable `PGCONNECT_TIMEOUT` is ignored rather than rejected — Data API users must not be broken by an unrelated variable in their environment.
- Parameter values are restricted by an inclusive character set rather than by excluding known separators, because Redshift splits the argument list using `isspace()`, which covers vertical tab and form feed as well as space and tab.
- `session_parameters` matches the name and shares the name validation of `redshift_user.session_parameters`, which manages the same kind of parameter as per-user defaults.

## Testing

- Verified against a live provisioned cluster: session parameters reach the server, and `query_group = superuser` routes to the superuser queue.
- Covered all combinations of provider configuration and the `PGCONNECT_TIMEOUT` / `PGOPTIONS` environment variables, including unset, valid and unusable values.

## Docs

- `docs/index.md` regenerated via `make doc`.

## Not included

`session_parameters` conflicts with `data_api` because the driver opens a fresh session per statement. The Data API itself supports what would be needed — I confirmed on a live cluster that `SET` persists both within a `BatchExecuteStatement` and across calls reusing a `SessionId` — but `redshift-data-sql-driver` exposes neither. Lifting this is driver work rather than a second configuration path, so I've left it out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
