### PR TITLE
fix(schema): stop reading SVL_QUERY_SUMMARY when refreshing a schema

### DIFF
--- a/redshift/config.go
+++ b/redshift/config.go
@@ -17,10 +17,6 @@ type Config struct {
 	Database   string
 	MaxConns   int
 
-	serverlessCheckMutex *sync.Mutex
-	isServerless         bool
-	checkedForServerless bool
-
 	usernameRetrievalMutex *sync.Mutex
 	retrievedUsername      string
 }
@@ -32,7 +28,6 @@ func NewConfig(driverName, connStr, database string, maxConns int) *Config {
 		Database:   database,
 		MaxConns:   maxConns,
 
-		serverlessCheckMutex:   &sync.Mutex{},
 		usernameRetrievalMutex: &sync.Mutex{},
 	}
 }
@@ -55,43 +50,6 @@ func (c *Config) NewClient() *Client {
 	return &Client{
 		config: *c,
 	}
-}
-
-func (c *Config) IsServerless(db *DBConnection) (bool, error) {
-	if c.serverlessCheckMutex == nil {
-		c.serverlessCheckMutex = &sync.Mutex{}
-	}
-	c.serverlessCheckMutex.Lock()
-	defer c.serverlessCheckMutex.Unlock()
-	if c.checkedForServerless {
-		return c.isServerless, nil
-	}
-
-	c.checkedForServerless = true
-
-	rows, err := db.Query("SELECT 1 FROM SYS_SERVERLESS_USAGE")
-	// No error means we have accessed the view and are running Redshift Serverless
-	if err == nil {
-		defer rows.Close()
-		c.isServerless = true
-		return true, nil
-	}
-
-	// Insuficcient privileges means we do not have access to this view ergo we run on Redshift classic
-	if isPqErrorWithCode(err, pgErrorCodeInsufficientPrivileges) {
-		rows, err = db.Query("SELECT 1 FROM SVL_QUERY_SUMMARY")
-		// An error means we are running Multi-AZ Provisioned Redshift which behaves in some cases as serverless
-		if err != nil {
-			c.isServerless = true
-			return true, nil
-		}
-		_ = rows.Close()
-
-		c.isServerless = false
-		return false, nil
-	}
-
-	return false, err
 }
 
 func (c *Config) GetUsername(db *DBConnection) (string, error) {

--- a/redshift/data_source_redshift_schema_test.go
+++ b/redshift/data_source_redshift_schema_test.go
@@ -22,7 +22,11 @@ func TestAccDataSourceRedshiftSchema_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.redshift_schema.schema", schemaNameAttr, schemaName),
 					resource.TestCheckResourceAttrSet("data.redshift_schema.schema", schemaOwnerAttr),
-					resource.TestCheckResourceAttrSet("data.redshift_schema.schema", schemaQuotaAttr),
+					// The quota is asserted by value, not merely as set: the data source
+					// looks the quota up by schema name rather than by oid, and it is the
+					// only caller whose name comes from configuration instead of from the
+					// database, so a lookup that silently finds nothing must fail here.
+					resource.TestCheckResourceAttr("data.redshift_schema.schema", schemaQuotaAttr, "15360"),
 				),
 			},
 		},
@@ -33,12 +37,13 @@ func testAccDataSourceRedshiftSchemaConfigBasic(schemaName string) string {
 	return fmt.Sprintf(`
 resource "redshift_schema" "schema" {
 	%[1]s = %[2]q
+	%[3]s = 15
 }
 
 data "redshift_schema" "schema" {
 	%[1]s = redshift_schema.schema.%[1]s
 }
-`, schemaNameAttr, schemaName)
+`, schemaNameAttr, schemaName, schemaQuotaAttr)
 }
 
 // Acceptance test for external redshift schema using AWS Glue Data Catalog

--- a/redshift/helpers.go
+++ b/redshift/helpers.go
@@ -24,8 +24,6 @@ const (
 	pqErrorDuplicateKeyViolation = "23505"
 
 	pqErrorCodeDuplicateSchema = "42P06"
-
-	pgErrorCodeInsufficientPrivileges = "42501"
 )
 
 // startTransaction starts a new DB transaction using the provided client.
@@ -114,10 +112,6 @@ func isRetryablePQError(code string) bool {
 
 	_, ok := retryable[code]
 	return ok
-}
-
-func isPqErrorWithCode(err error, code string) bool {
-	return string(err.(*pq.Error).Code) == code
 }
 
 func splitCsvAndTrim(raw string) ([]string, error) {

--- a/redshift/resource_redshift_schema.go
+++ b/redshift/resource_redshift_schema.go
@@ -440,31 +440,35 @@ func resourceRedshiftSchemaReadImpl(db *DBConnection, d *schema.ResourceData) er
 }
 
 func resourceRedshiftSchemaReadLocal(db *DBConnection, d *schema.ResourceData) error {
-	var schemaQuota = 0
-	isServerless, err := db.client.config.IsServerless(db)
-	if err != nil {
+	// svv_redshift_schema_quota reports the quota in MB on every cluster type, so one
+	// query serves Serverless, Multi-AZ and single-AZ provisioned alike. The view also
+	// lists schemas of datashare-visible databases, and its shared-schema rows join the
+	// quota on schema_id alone, which is unique only within a database -- so constraining
+	// database_name is what keeps this lookup unambiguous.
+	//
+	// Every schema of the connected database is listed, carrying a NULL quota when none
+	// is set. A missing row therefore means the lookup failed rather than that the schema
+	// is unlimited, and reporting that as quota 0 would produce a phantom diff that
+	// Terraform would "correct" by clearing a live quota.
+	var schemaQuota sql.NullInt64
+	err := db.QueryRow(`
+		SELECT quota
+		FROM svv_redshift_schema_quota
+		WHERE database_name = $1
+		  AND schema_name = $2
+	`, db.client.config.Database, d.Get(schemaNameAttr)).Scan(&schemaQuota)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return fmt.Errorf("schema %q was not found in svv_redshift_schema_quota for database %q: cannot determine its quota", d.Get(schemaNameAttr), db.client.config.Database)
+	case err != nil:
 		return err
 	}
-
-	if isServerless {
-		err = db.QueryRow(`
-			SELECT COALESCE(quota, 0)
-			FROM svv_redshift_schema_quota
-			WHERE database_name = $1 
-			  AND schema_name = $2
-		`, db.client.config.Database, d.Get(schemaNameAttr)).Scan(&schemaQuota)
-	} else {
-		err = db.QueryRow(`
-			SELECT
-			COALESCE(quota, 0)
-			FROM svv_schema_quota_state
-			WHERE schema_id = $1
-		`, d.Id()).Scan(&schemaQuota)
+	// A NULL quota means the schema is unlimited, which the resource models as 0.
+	quota := 0
+	if schemaQuota.Valid {
+		quota = int(schemaQuota.Int64)
 	}
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return err
-	}
-	d.Set(schemaQuotaAttr, schemaQuota)
+	d.Set(schemaQuotaAttr, quota)
 	d.Set(schemaExternalSchemaAttr, nil)
 
 	return nil

--- a/redshift/resource_redshift_schema_test.go
+++ b/redshift/resource_redshift_schema_test.go
@@ -37,7 +37,17 @@ func TestAccRedshiftSchema_Basic(t *testing.T) {
 
 					testAccCheckRedshiftSchemaExists("wOoOT_I22_@tH15"),
 					resource.TestCheckResourceAttr("redshift_schema.fancy_name", "name", "wooot_i22_@th15"),
+					resource.TestCheckResourceAttr("redshift_schema.fancy_name", "quota", "5120"),
 				),
+			},
+			{
+				// Refreshing must reproduce what was just applied. The quota is read back
+				// by schema name, so a name that Redshift folds, or a quota the read
+				// resolves to 0 because it failed to find its row, shows up here as a
+				// non-empty plan rather than as a passing test.
+				Config:             testAccRedshiftSchemaConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -631,6 +641,7 @@ resource "redshift_schema" "schema_configured" {
 
 resource "redshift_schema" "fancy_name" {
   name = "wOoOT_I22_@tH15"
+  quota = 5
 }
 
 resource "redshift_user" "schema_test_user1" {


### PR DESCRIPTION
## Summary

Refreshing a `redshift_schema` on a provisioned cluster runs `SELECT 1 FROM SVL_QUERY_SUMMARY` unbounded, which takes **106s on an idle cluster** and over **1600s under concurrency** — long enough that CI runners kill the plan before it prints a diff. This PR deletes that query. It existed only to classify the cluster, and the classification is no longer needed: provisioned and serverless both expose `svv_redshift_schema_quota`.

Fixes #39.

## Root cause

`Config.IsServerless` probes `SYS_SERVERLESS_USAGE`; a provisioned cluster returns `42501`, so it falls through to the `SVL_QUERY_SUMMARY` scan. `LIMIT 1` does not bound it (>123s) because the view is materialised before the limit applies. The result is used for exactly one thing — choosing between `svv_redshift_schema_quota` and `svv_schema_quota_state`.

Only `redshift_schema` reaches this path, so configurations of users, grants, groups and roles are unaffected.

## Change

`resourceRedshiftSchemaReadLocal` queries `svv_redshift_schema_quota` unconditionally. `IsServerless` and both probes are deleted.

Serverless and Multi-AZ provisioned already used that view, so single-AZ provisioned is the only case whose behaviour moves. There the two views agree — a schema created with `QUOTA 15 GB` reports `15360` from both — and so does row visibility: both are gated on `USAGE`, as is `svv_all_schemas`, which the read already queries to resolve the oid. Measured as a non-superuser: 31 schemas with `USAGE`, 31 rows in the view, 29 of them owned by other users.

**One behaviour change.** A missing row is now an error instead of `quota = 0`. `svv_schema_quota_state` held rows only for schemas that have a quota, so "no row" meant "no quota". The new view lists every schema, carrying a NULL quota when none is set — so an absent row means the lookup failed, and reporting it as 0 would make Terraform clear a live quota to match. NULL still maps to 0.

This also removes `isPqErrorWithCode`, whose unchecked `err.(*pq.Error)` assertion panics on errors from any other driver. `IsServerless` reached that line only when the first probe failed, i.e. the Data API against a provisioned cluster.

## Testing

Acceptance tests pass against a live single-AZ `ra3.xlplus` cluster over libpq: `TestAccRedshiftSchema_Basic`, `_Update`, `_UpdateComplex`, `TestAccDataSourceRedshiftSchema_basic`.

Three test changes, all on the read this PR modifies:

- The data source asserted `TestCheckResourceAttrSet(…, "quota")`, which **cannot fail** — `d.Set` is unconditional, so the attribute is set even when the lookup finds nothing. It now asserts the value; forcing the read to yield 0 fails it with `Attribute 'quota' expected "15360", got "0"`.
- `wOoOT_I22_@tH15` now carries a quota, so identifier folding and the name-keyed lookup are exercised together.
- A `PlanOnly` step after the quota apply, so a refresh must reproduce what was written.

No generated doc changes — no schema `Description` was touched.

## Not verified

`svv_redshift_schema_quota` is confirmed on `ra3` on the `current` maintenance track; no DC2 or trailing-track cluster was available to test. If the view were absent there the read now fails visibly with `42P01` rather than silently returning 0.
